### PR TITLE
✨ Add `Stringifiable` type

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ language.
 ## 🍎 Base Types
 
 - [`NumberLiteral`](src/number-literal.ts): A stringified number literal.
+- [`Stringifiable`](src/stringifiable.ts): An alias for `string | number | bigint | boolean | null | undefined`.
 - [`UnknownArray`](src/unknown-array.ts): An alias for `unknown[] | readonly unknown[]`,
   safer than `any`.
 - [`UnknownRecord`](src/unknown-record.ts): An alias for `Record<PropertyKey, unknown>`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ export type { UnionLiteral } from 'type-space/union-literal'
 
 // base
 export type { NumberLiteral } from 'type-space/number-literal'
+export type { Stringifiable } from 'type-space/stringifiable'
 export type { UnknownArray } from 'type-space/unknown-array'
 export type { UnknownRecord } from 'type-space/unknown-record'
 

--- a/src/stringifiable.ts
+++ b/src/stringifiable.ts
@@ -1,0 +1,10 @@
+/**
+ * A type that can be converted to a string using template literal syntax.
+ */
+export type Stringifiable =
+	| string
+	| number
+	| bigint
+	| boolean
+	| null
+	| undefined

--- a/src/stringify.ts
+++ b/src/stringify.ts
@@ -1,3 +1,5 @@
+import type { Stringifiable } from './stringifiable'
+
 /**
  * Converts a type to a template literal type, if possible.
  *
@@ -6,12 +8,4 @@
  * Stringify<1 | 2> // '1' | '2'
  * ```
  */
-export type Stringify<T> = T extends
-	| string
-	| number
-	| bigint
-	| boolean
-	| null
-	| undefined
-	? `${T}`
-	: never
+export type Stringify<T> = T extends Stringifiable ? `${T}` : never


### PR DESCRIPTION
"Basic" alias for types that can be used with template literal syntax.