### PR TITLE
manually add index.js to dist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,7 +80,8 @@ typings/
 
 # Nuxt.js build / generate output
 .nuxt
-dist
+dist/*
+!dist/index.js
 
 # Gatsby files
 .cache/

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,0 +1,1 @@
+// @cuppachino/type-space

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@cuppachino/type-space",
-	"version": "1.13.1",
+	"version": "1.13.2",
 	"license": "gpl-3.0",
 	"author": {
 		"name": "Cuppachino",
@@ -17,7 +17,7 @@
 		"type-utilities",
 		"generic-types"
 	],
-	"main": "./dist/index.d.ts",
+	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",
 	"files": [
 		"dist"


### PR DESCRIPTION
This should let websites like Bundlephobia scan the package properly. I think the "Failed to build this package" error is because I was linked "main" in package.json to a `.d.ts` file