### PR TITLE
Type-Space Tuesday

### DIFF
--- a/.changeset/five-jobs-poke.md
+++ b/.changeset/five-jobs-poke.md
@@ -1,0 +1,5 @@
+---
+'@cuppachino/type-space': minor
+---
+
+Add NumberLike, Chars, PopBy, ShiftBy, IntoNumber, IntoNumberLiteral, Assert, SplitAt, StringIncludes, StringIncludesProper

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,7 +14,7 @@
 	},
 	"editor.defaultFormatter": "dbaeumer.vscode-eslint",
 	"[typescript]": {
-		"editor.defaultFormatter": "dbaeumer.vscode-eslint"
+		"editor.defaultFormatter": "esbenp.prettier-vscode"
 	},
 	"[jsonc]": {
 		"editor.defaultFormatter": "esbenp.prettier-vscode"

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ The source code is fully tsdoc'd, so you can use your IDE's intellisense to refe
 - [`Split`](src/split.ts): Splits a string literal into a tuple of characters, separated by the given delimiter.
 - [`SplitAt`](src/strings/split-at.ts): Split a string literal into a tuple of two strings, separated by the given index, non-inclusive.
 - [`Stringify`](src/stringify.ts): Converts a type to a string literal type, if possible.
+- [`StringIncludes`](src/string-includes.ts): A boolean type that is true if a string literal includes a given substring (⊆).
 
 ## 📜 Tuple Types
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ The source code is fully tsdoc'd, so you can use your IDE's intellisense to refe
 - [`IsPositive`](src/math/is-positive.ts): A boolean type that is true if a number literal is positive.
 - [`IsNegative`](src/math/is-negative.ts): A boolean type that is true if a number literal is negative.
 - [`IsWhole`](src/math/is-whole.ts): A boolean type that is true if a number literal is a whole number.
+- [`NumberLike`](src/number-like.ts): Coerce either a `number` or a `NumberLiteral` into a union between the two.
 - [`ParseNumberLiteral`](src/parse-number-literal.ts): Coerce a `NumberLiteral` type to a `number`
 
 ## 💭 String Types

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ The source code is fully tsdoc'd, so you can use your IDE's intellisense to refe
 - [`SplitAt`](src/strings/split-at.ts): Split a string literal into a tuple of two strings, separated by the given index, non-inclusive.
 - [`Stringify`](src/stringify.ts): Converts a type to a string literal type, if possible.
 - [`StringIncludes`](src/string-includes.ts): A boolean type that is true if a string literal includes a given substring (⊆).
+- [`StringIncludesProper`](src/string-includes-proper.ts): A boolean type that is true if a string literal includes a given substring, and the substring is not the entire string (⊂).
 
 ## 📜 Tuple Types
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ The source code is fully tsdoc'd, so you can use your IDE's intellisense to refe
 > ```
 
 - [`Pop`](src/tuples/pop.ts): Removes the last element from a tuple. Does not return the removed element.
+- [`PopBy`](src/tuples/pop-by.ts): Remove the last `N` elements from a tuple.
 - [`Push`](src/tuples/push.ts): Adds one element type to the end of a tuple. Does not return the new length of the tuple.
 - [`Shift`](src/tuples/shift.ts): Removes the first element from a tuple type. Does not return the removed element.
 - [`Unshift`](src/tuples/unshift.ts): Adds one element type to the beginning of a tuple. Does not return the new length of the tuple.

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ The source code is fully tsdoc'd, so you can use your IDE's intellisense to refe
 
 - [`Chars`](src/chars.ts): Splits a string literal into a tuple of characters. Reads more clearly than `Split` in some cases.
 - [`Split`](src/split.ts): Splits a string literal into a tuple of characters, separated by the given delimiter.
+- [`SplitAt`](src/strings/split-at.ts): Split a string literal into a tuple of two strings, separated by the given index, non-inclusive.
 - [`Stringify`](src/stringify.ts): Converts a type to a string literal type, if possible.
 
 ## 📜 Tuple Types
@@ -95,6 +96,7 @@ The source code is fully tsdoc'd, so you can use your IDE's intellisense to refe
 
 ## 🧰 Utility Types
 
+- [`Assert`](src/assert.ts): Assert that a type is assignable to another type; shorthand for `T extends U ? T : never`.
 - [`Combine`](src/combine.ts): Simplify a type by mapping over its properties.
 - [`KeyOf`](src/key-of.ts): Extract all keys from every member of a union type, unlike `keyof` which only preserves shared members' keys.
 - [`Mutable`](src/mutable.ts): Recursively removes the `readonly` modifier from all properties of a type.

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ The source code is fully tsdoc'd, so you can use your IDE's intellisense to refe
 - [`PopBy`](src/tuples/pop-by.ts): Remove the last `N` elements from a tuple.
 - [`Push`](src/tuples/push.ts): Adds one element type to the end of a tuple. Does not return the new length of the tuple.
 - [`Shift`](src/tuples/shift.ts): Removes the first element from a tuple type. Does not return the removed element.
+- [`ShiftBy`](src/tuples/shift-by.ts): Remove the first `N` elements from a tuple.
 - [`Unshift`](src/tuples/unshift.ts): Adds one element type to the beginning of a tuple. Does not return the new length of the tuple.
 
 ## 🧰 Utility Types

--- a/README.md
+++ b/README.md
@@ -84,10 +84,10 @@ The source code is fully tsdoc'd, so you can use your IDE's intellisense to refe
 > Action :: <Tuple> -> NewTuple
 > ```
 
-- [`Pop`](src/tuples/pop.ts): Removes the last element from a tuple. Does not return the removed element.
+- [`Pop`](src/tuples/pop.ts): Remove the last element from a tuple. Does not return the removed element.
 - [`PopBy`](src/tuples/pop-by.ts): Remove the last `N` elements from a tuple.
 - [`Push`](src/tuples/push.ts): Adds one element type to the end of a tuple. Does not return the new length of the tuple.
-- [`Shift`](src/tuples/shift.ts): Removes the first element from a tuple type. Does not return the removed element.
+- [`Shift`](src/tuples/shift.ts): Remove the first element from a tuple type. Does not return the removed element.
 - [`ShiftBy`](src/tuples/shift-by.ts): Remove the first `N` elements from a tuple.
 - [`Unshift`](src/tuples/unshift.ts): Adds one element type to the beginning of a tuple. Does not return the new length of the tuple.
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ The source code is fully tsdoc'd, so you can use your IDE's intellisense to refe
 
 ## 🔢 Numeric Types
 
+- [`IntoNumber`](src/into-number.ts): Coerce a `NumberLike` type to a `number`
+- [`IntoNumberLiteral`](src/into-number-literal.ts): Coerce a `NumberLike` type to a `NumberLiteral`
 - [`IsInteger`](src/math/is-integer.ts): A boolean type that is true if a number literal is an integer.
 - [`IsPositive`](src/math/is-positive.ts): A boolean type that is true if a number literal is positive.
 - [`IsNegative`](src/math/is-negative.ts): A boolean type that is true if a number literal is negative.

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ The source code is fully tsdoc'd, so you can use your IDE's intellisense to refe
 ## 🧮 Arithmetic Types
 
 - [`Absolute`](src/math/absolute.ts): Coerces a number literal to a positive `number` of the same magnitude.
-- [`Add`](src/math/add.ts): Returns the sum of two number literals.
-- [`Subtract`](src/math/subtract.ts): Returns the difference between two number literals.
+- [`Add`](src/math/add.ts): Return the sum of two number literals.
+- [`Subtract`](src/math/subtract.ts): Return the difference between two number literals.
 
 ## 🔢 Numeric Types
 
@@ -52,7 +52,7 @@ The source code is fully tsdoc'd, so you can use your IDE's intellisense to refe
 - [`IsPositive`](src/math/is-positive.ts): A boolean type that is true if a number literal is positive.
 - [`IsNegative`](src/math/is-negative.ts): A boolean type that is true if a number literal is negative.
 - [`IsWhole`](src/math/is-whole.ts): A boolean type that is true if a number literal is a whole number.
-- [`ParseNumberLiteral`](src/parse-number-literal.ts): Coerces a `NumberLiteral` type to a `number`
+- [`ParseNumberLiteral`](src/parse-number-literal.ts): Coerce a `NumberLiteral` type to a `number`
 
 ## 💭 String Types
 
@@ -61,12 +61,12 @@ The source code is fully tsdoc'd, so you can use your IDE's intellisense to refe
 
 ## 📜 Tuple Types
 
-- [`CreateTuple`](src/create-tuple.ts): Generates a fixed-length tuple.
+- [`CreateTuple`](src/create-tuple.ts): Generate a fixed-length tuple.
 - [`Flat`](src/flat.ts): Recursively flatten a tuple up to a given depth.
-- [`IndexOf`](src/index-of.ts): Returns a union of a tuple's indices.
-- [`Indices`](src/indices.ts): Generates a tuple of a tuple's indices.
+- [`IndexOf`](src/index-of.ts): Return a union of a tuple's indices.
+- [`Indices`](src/indices.ts): Generate a tuple of a tuple's indices.
 - [`Join`](src/join.ts): Joins a tuple of strings into a single string, separated by a delimiter.
-- [`Length`](src/length.ts): Extracts the length property from an array or
+- [`Length`](src/length.ts): Extract the length property from an array or
   tuple.
 - [`MergeAll`](src/merge-all.ts): Merge all type members of a tuple into a
   single type.
@@ -89,23 +89,23 @@ The source code is fully tsdoc'd, so you can use your IDE's intellisense to refe
 
 ## 🧰 Utility Types
 
-- [`Combine`](src/combine.ts): Simplifies a type by mapping over its properties.
-- [`KeyOf`](src/key-of.ts): Extracts all keys from every member of a union type, unlike `keyof` which only preserves shared members' keys.
+- [`Combine`](src/combine.ts): Simplify a type by mapping over its properties.
+- [`KeyOf`](src/key-of.ts): Extract all keys from every member of a union type, unlike `keyof` which only preserves shared members' keys.
 - [`Mutable`](src/mutable.ts): Recursively removes the `readonly` modifier from all properties of a type.
-- [`PartialSome`](src/partial-some.ts): Returns a new type that allows the specified keys to be undefined.
+- [`PartialSome`](src/partial-some.ts): Return a new type that allows the specified keys to be undefined.
 - [`PickAll`](src/pick-all.ts): Extract properties from _all_ members in a union, missing properties default to `| undefined`.
-- [`Simplify`](src/simplify.ts): Simplifies a type by mapping over its inferred properties - use when `Combine` cannot infer a deep type.
+- [`Simplify`](src/simplify.ts): Simplify a type by mapping over its inferred properties - use when `Combine` cannot infer a deep type.
 - [`Subset`](src/subset.ts): TypeScript equivalent of `⊆`.
 - [`UnionLiteral`](src/union-literal.ts): Create a union from a literal and primitive type without losing the literal type.
 - [`UnionToIntersection`](src/union-to-intersection.ts): Create an intersection from all members of a union type.
 
 ### Extract
 
-- [`ExtractRequired`](src/extract/extract-required.ts): Extracts all non-optional properties from a type; ℹ️[exactOptionalPropertyTypes](https://www.typescriptlang.org/tsconfig#exactOptionalPropertyTypes).
-- [`ExtractOptional`](src/extract/extract-optional.ts): Extracts all optional properties from a type; ℹ️[exactOptionalPropertyTypes](https://www.typescriptlang.org/tsconfig#exactOptionalPropertyTypes)
-- [`ExtractFunctions`](src/extract/extract-functions.ts): Creates a new type of
+- [`ExtractRequired`](src/extract/extract-required.ts): Extract all non-optional properties from a type; ℹ️[exactOptionalPropertyTypes](https://www.typescriptlang.org/tsconfig#exactOptionalPropertyTypes).
+- [`ExtractOptional`](src/extract/extract-optional.ts): Extract all optional properties from a type; ℹ️[exactOptionalPropertyTypes](https://www.typescriptlang.org/tsconfig#exactOptionalPropertyTypes)
+- [`ExtractFunctions`](src/extract/extract-functions.ts): Create a new type of
   all property functions and methods in a type.
-- [`ExtractSetMembers`](src/extract/extract-set-members.ts): Creates a union
+- [`ExtractSetMembers`](src/extract/extract-set-members.ts): Create a union
   type of members in a `Set`.
 
 ### Extends
@@ -119,7 +119,7 @@ The source code is fully tsdoc'd, so you can use your IDE's intellisense to refe
 > - `T` is the type to check.
 > - `R` is the type returned when `T` extends the name of the generic.
 
-- [`ExtendsFunction`](src/extends/extends-function.ts): Returns a type if the
+- [`ExtendsFunction`](src/extends/extends-function.ts): Return a type if the
   given type extends a function or method.
 
 ---

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ The source code is fully tsdoc'd, so you can use your IDE's intellisense to refe
 
 ## 💭 String Types
 
+- [`Chars`](src/chars.ts): Splits a string literal into a tuple of characters. Reads more clearly than `Split` in some cases.
 - [`Split`](src/split.ts): Splits a string literal into a tuple of characters, separated by the given delimiter.
 - [`Stringify`](src/stringify.ts): Converts a type to a string literal type, if possible.
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
 	],
 	"packageManager": "pnpm@7.29.3",
 	"scripts": {
-		"test": "pnpm clear && jest -c jest.config.tsd.js",
+		"test": "pnpm clear && pnpm tsc --noEmit --emitDeclarationOnly false && jest -c jest.config.tsd.js",
 		"lint": "prettier -c . -w && pnpm eslint . --fix",
 		"build": "tsc --build --clean && tsc --project tsconfig.json && tsc-alias -p tsconfig.json",
 		"package": "pnpm pack --pack-destination release",

--- a/src/assert.ts
+++ b/src/assert.ts
@@ -1,0 +1,4 @@
+/**
+ * Shorthand `extends` check.
+ */
+export type Assert<T, U> = T extends U ? T : never

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ export type { PickAll } from 'type-space/pick-all'
 // strings
 export type { Chars } from 'type-space/strings/chars'
 export type { Split } from 'type-space/split'
+export type { SplitAt } from 'type-space/strings/split-at'
 export type { Stringify } from 'type-space/stringify'
 
 // numbers / strings
@@ -31,6 +32,7 @@ export type { Unshift } from 'type-space/tuples/unshift'
 export type { ShiftBy } from 'type-space/tuples/shift-by'
 
 // utility
+export type { Assert } from 'type-space/assert'
 export type { Combine } from 'type-space/combine'
 export type { Simplify } from 'type-space/simplify'
 export type { Subset } from 'type-space/subset'

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,8 @@ export type { Stringify } from 'type-space/stringify'
 
 // numbers / strings
 export type { NumberLike } from 'type-space/number-like'
+export type { IntoNumber } from 'type-space/into/into-number'
+export type { IntoNumberLiteral } from 'type-space/into/into-number-literal'
 
 // tuples
 export type { Pop } from 'type-space/tuples/pop'

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ export type { NumberLike } from 'type-space/number-like'
 
 // tuples
 export type { Pop } from 'type-space/tuples/pop'
+export type { PopBy } from 'type-space/tuples/pop-by'
 export type { Push } from 'type-space/tuples/push'
 export type { Shift } from 'type-space/tuples/shift'
 export type { Unshift } from 'type-space/tuples/unshift'

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ export type { Split } from 'type-space/split'
 export type { SplitAt } from 'type-space/strings/split-at'
 export type { Stringify } from 'type-space/stringify'
 export type { StringIncludes } from 'type-space/strings/string-includes'
+export type { StringIncludesProper } from 'type-space/strings/string-includes-proper'
 
 // numbers / strings
 export type { NumberLike } from 'type-space/number-like'

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ export type { Chars } from 'type-space/strings/chars'
 export type { Split } from 'type-space/split'
 export type { SplitAt } from 'type-space/strings/split-at'
 export type { Stringify } from 'type-space/stringify'
+export type { StringIncludes } from 'type-space/strings/string-includes'
 
 // numbers / strings
 export type { NumberLike } from 'type-space/number-like'

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,9 @@ export type { Mutable } from 'type-space/mutable'
 export type { ParseNumberLiteral } from 'type-space/parse-number-literal'
 export type { PartialSome } from 'type-space/partial-some'
 export type { PickAll } from 'type-space/pick-all'
+
+// strings
+export type { Chars } from 'type-space/strings/chars'
 export type { Split } from 'type-space/split'
 export type { Stringify } from 'type-space/stringify'
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,9 @@ export type { PickAll } from 'type-space/pick-all'
 export type { Split } from 'type-space/split'
 export type { Stringify } from 'type-space/stringify'
 
+// numbers / strings
+export type { NumberLike } from 'type-space/number-like'
+
 // tuples
 export type { Pop } from 'type-space/tuples/pop'
 export type { Push } from 'type-space/tuples/push'

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ export type { PopBy } from 'type-space/tuples/pop-by'
 export type { Push } from 'type-space/tuples/push'
 export type { Shift } from 'type-space/tuples/shift'
 export type { Unshift } from 'type-space/tuples/unshift'
+export type { ShiftBy } from 'type-space/tuples/shift-by'
 
 // utility
 export type { Combine } from 'type-space/combine'

--- a/src/into/into-number-literal.ts
+++ b/src/into/into-number-literal.ts
@@ -1,0 +1,14 @@
+import type { NumberLiteral } from '../number-literal'
+
+/**
+ * Coerce either a `number` or a `NumberLiteral` into a `NumberLiteral`.
+ *
+ * @remarks This is useful for finalizing a `NumberLike` into a `NumberLiteral`.
+ * @example
+ * ```
+ * type A = IntoNumberLiteral<1> // "1"
+ * type B = IntoNumberLiteral<"1"> // "1"
+ * ```
+ */
+export type IntoNumberLiteral<T extends number | NumberLiteral> =
+	T extends NumberLiteral ? T : `${T}`

--- a/src/into/into-number.ts
+++ b/src/into/into-number.ts
@@ -1,0 +1,14 @@
+import type { NumberLiteral, ParseNumberLiteral } from 'type-space'
+
+/**
+ * Coerce either a `number` or a `NumberLiteral` into a `number`.
+ *
+ * @remarks This is useful for finalizing a `NumberLike` into a `number`.
+ * @example
+ * ```
+ * type A = IntoNumber<1> // 1
+ * type B = IntoNumber<"1"> // 1
+ * ```
+ */
+export type IntoNumber<T extends number | NumberLiteral> =
+	T extends NumberLiteral ? ParseNumberLiteral<T> : T

--- a/src/number-like.ts
+++ b/src/number-like.ts
@@ -1,0 +1,25 @@
+import type { NumberLiteral } from './number-literal'
+import type { ParseNumberLiteral } from './parse-number-literal'
+
+/**
+ * Coerce either a `number` or a `NumberLiteral` into a union between the two.
+ *
+ * @remarks This is useful for when you want to accept a `number` or a `NumberLiteral` but you want to choose which one to use later.
+ * @example
+ * ```
+ * type A = NumberLike<1> // 1 | "1"
+ * ```
+ * @example Accepting a `NumberLike` and returning a `NumberLiteral`
+ * ```
+ * type IntoNumberLiteral<T extends number | NumberLiteral> =
+ * 	T extends NumberLiteral ? T : `${T}`
+ * ```
+ * @example Accepting a `NumberLike` and returning a `number`
+ * ```
+ * type IntoNumber<T extends number | NumberLiteral> = T extends NumberLiteral
+ * 	? ParseNumberLiteral<T>
+ * 	: T
+ * ```
+ */
+export type NumberLike<T extends number | NumberLiteral> =
+	T extends NumberLiteral ? ParseNumberLiteral<T> | T : `${T}` | T

--- a/src/strings/chars.ts
+++ b/src/strings/chars.ts
@@ -1,0 +1,23 @@
+import type { Equal, ExpectFalse, ExpectTrue } from '@type-challenges/utils'
+
+/**
+ * Split a string literal into an tuple of characters.
+ *
+ * @example
+ * ```
+ * type MyChars = Chars<'abc'> // ['a', 'b', 'c']
+ * ```
+ */
+export type Chars<
+	S extends string,
+	A extends string[] = []
+> = S extends `${infer C}${infer R}` ? Chars<R, [...A, C]> : A
+
+/**
+ * @internal
+ */
+type _Chars_Cases = [
+	ExpectTrue<Equal<Chars<'abc'>, ['a', 'b', 'c']>>,
+	ExpectTrue<Equal<Chars<'abc', ['d']>, ['d', 'a', 'b', 'c']>>,
+	ExpectFalse<Equal<Chars<'abc'>, ['', 'abc']>>
+]

--- a/src/strings/split-at.ts
+++ b/src/strings/split-at.ts
@@ -1,0 +1,54 @@
+import type { Equal, Expect } from '@type-challenges/utils'
+import type { Assert } from '../assert'
+import type { Chars } from './chars'
+import type { IndexOf } from '../index-of'
+import type { IntoNumber } from '../into/into-number'
+import type { Join } from '../join'
+import type { Length } from '../length'
+import type { NumberLike } from '../number-like'
+import type { PopBy } from '../tuples/pop-by'
+import type { ShiftBy } from '../tuples/shift-by'
+import type { Stringifiable } from '../stringifiable'
+import type { Subtract } from '../math/subtract'
+
+/**
+ * Splits a string literal at a given index, non-inclusive.
+ *
+ * @param S - The string literal to split.
+ * @param I - A number or number literal. Must be an index of `S`.
+ * @example
+ * ```
+ * type A = SplitAt<'david', '2'> // ['da', 'vid']
+ * type B = SplitAt<'david', 5> // ['david', '']
+ * ```
+ */
+export type SplitAt<
+	S extends string,
+	I extends NumberLike<IndexOf<[...Chars<S>, never]>> = Assert<
+		0,
+		NumberLike<IndexOf<[...Chars<S>, never]>>
+	>
+> = Chars<S> extends infer C extends Stringifiable[]
+	? [
+			Join<PopBy<C, Subtract<Length<C>, IntoNumber<I>>>>,
+			Join<ShiftBy<C, IntoNumber<I>>>
+	  ]
+	: never
+
+/**
+ * @internal
+ */
+type _SplitAt_Cases = [
+	Expect<Equal<SplitAt<'david', '0'>, ['', 'david']>>,
+	Expect<Equal<SplitAt<'david', '1'>, ['d', 'avid']>>,
+	Expect<Equal<SplitAt<'david', '2'>, ['da', 'vid']>>,
+	Expect<Equal<SplitAt<'david', '3'>, ['dav', 'id']>>,
+	Expect<Equal<SplitAt<'david', '4'>, ['davi', 'd']>>,
+	Expect<Equal<SplitAt<'david', '5'>, ['david', '']>>,
+	Expect<Equal<SplitAt<'david', 0>, ['', 'david']>>,
+	Expect<Equal<SplitAt<'david', 1>, ['d', 'avid']>>,
+	Expect<Equal<SplitAt<'david', 2>, ['da', 'vid']>>,
+	Expect<Equal<SplitAt<'david', 3>, ['dav', 'id']>>,
+	Expect<Equal<SplitAt<'david', 4>, ['davi', 'd']>>,
+	Expect<Equal<SplitAt<'david', 5>, ['david', '']>>
+]

--- a/src/strings/split-at.ts
+++ b/src/strings/split-at.ts
@@ -24,9 +24,9 @@ import type { Subtract } from '../math/subtract'
  */
 export type SplitAt<
 	S extends string,
-	I extends NumberLike<IndexOf<[...Chars<S>, never]>> = Assert<
-		0,
-		NumberLike<IndexOf<[...Chars<S>, never]>>
+	I extends NumberLike<IndexOf<[...Chars<S>]>> = Assert<
+		NumberLike<0>,
+		NumberLike<IndexOf<[...Chars<S>]>>
 	>
 > = Chars<S> extends infer C extends Stringifiable[]
 	? [
@@ -44,11 +44,11 @@ type _SplitAt_Cases = [
 	Expect<Equal<SplitAt<'david', '2'>, ['da', 'vid']>>,
 	Expect<Equal<SplitAt<'david', '3'>, ['dav', 'id']>>,
 	Expect<Equal<SplitAt<'david', '4'>, ['davi', 'd']>>,
-	Expect<Equal<SplitAt<'david', '5'>, ['david', '']>>,
+	// Expect<Equal<SplitAt<'david', '5'>, ['david', '']>>, // this can be done if I extends NumberLike<Length<[...Chars<S>, never]>>
 	Expect<Equal<SplitAt<'david', 0>, ['', 'david']>>,
 	Expect<Equal<SplitAt<'david', 1>, ['d', 'avid']>>,
 	Expect<Equal<SplitAt<'david', 2>, ['da', 'vid']>>,
 	Expect<Equal<SplitAt<'david', 3>, ['dav', 'id']>>,
-	Expect<Equal<SplitAt<'david', 4>, ['davi', 'd']>>,
-	Expect<Equal<SplitAt<'david', 5>, ['david', '']>>
+	Expect<Equal<SplitAt<'david', 4>, ['davi', 'd']>>
+	// Expect<Equal<SplitAt<'david', 5>, ['david', '']>> // but should it really be allowed? I think not.
 ]

--- a/src/strings/string-includes-proper.ts
+++ b/src/strings/string-includes-proper.ts
@@ -1,0 +1,80 @@
+import type { ExpectFalse, ExpectTrue, NotEqual } from '@type-challenges/utils'
+import type { Assert } from '../assert'
+import type { Chars } from './chars'
+import type { IndexOf } from '../index-of'
+import type { NumberLike } from '../number-like'
+import type { SplitAt } from './split-at'
+import type { StringIncludes } from './string-includes'
+
+/**
+ * Check if a string literal includes another string literal, proper (⊂).
+ *
+ * @example
+ * ```
+ * type _StringIncludesProper_Cases = [
+ * 	ExpectTrue<StringIncludesProper<'abc', 'a'>>,
+ * 	ExpectTrue<StringIncludesProper<'abc', 'bc'>>,
+ * 	ExpectFalse<StringIncludesProper<'abc', 'abc'>>,
+ * 	ExpectFalse<StringIncludesProper<'NOT', 'NOT-INCLUDE'>>,
+ * 	//
+ * 	ExpectTrue<StringIncludesProper<'abc', '', 0>>,
+ * 	ExpectTrue<StringIncludesProper<'abc', '', '0'>>,
+ * 	ExpectTrue<StringIncludesProper<'abc', 'a', '0'>>,
+ * 	ExpectTrue<StringIncludesProper<'abc', 'b', '0'>>,
+ * 	ExpectFalse<StringIncludesProper<'abc', 'abc', '0'>>,
+ * 	ExpectFalse<StringIncludesProper<'NOT', 'NOT-INCLUDE', '0'>>,
+ * 	//
+ * 	ExpectTrue<StringIncludesProper<'abc', 'b', 1>>,
+ * 	ExpectFalse<StringIncludesProper<'abc', 'bc', '1'>>,
+ * 	ExpectFalse<StringIncludesProper<'abc', 'a', '1'>>,
+ * 	ExpectFalse<StringIncludesProper<'abc', 'ab', '1'>>,
+ * 	ExpectFalse<StringIncludesProper<'NOT', 'NOT-INCLUDE', '1'>>,
+ * 	//
+ * 	ExpectFalse<StringIncludesProper<'abc', 'c', 2>>,
+ * 	ExpectFalse<StringIncludesProper<'abc', 'c', '2'>>,
+ * 	ExpectFalse<StringIncludesProper<'abc', 'a', '2'>>,
+ * 	ExpectFalse<StringIncludesProper<'abc', 'ab', '2'>>,
+ * 	ExpectFalse<StringIncludesProper<'abc', 'abc', '2'>>,
+ * 	ExpectFalse<StringIncludesProper<'NOT', 'NOT-INCLUDE', '2'>>
+ * ]
+ * ```
+ */
+export type StringIncludesProper<
+	T extends string,
+	S extends string,
+	I extends NumberLike<IndexOf<Chars<T>>> = Assert<
+		0,
+		NumberLike<IndexOf<Chars<T>>>
+	>
+> = SplitAt<T, I> extends [infer _A, infer B extends string]
+	? NotEqual<B, S> extends true
+		? StringIncludes<B, S>
+		: false
+	: never
+
+type _StringIncludesProper_Cases = /* ⊂ */ [
+	ExpectTrue<StringIncludesProper<'abc', 'a'>>,
+	ExpectTrue<StringIncludesProper<'abc', 'bc'>>,
+	ExpectFalse<StringIncludesProper<'abc', 'abc'>>,
+	ExpectFalse<StringIncludesProper<'NOT', 'NOT-INCLUDE'>>,
+	//
+	ExpectTrue<StringIncludesProper<'abc', '', 0>>,
+	ExpectTrue<StringIncludesProper<'abc', '', '0'>>,
+	ExpectTrue<StringIncludesProper<'abc', 'a', '0'>>,
+	ExpectTrue<StringIncludesProper<'abc', 'b', '0'>>,
+	ExpectFalse<StringIncludesProper<'abc', 'abc', '0'>>,
+	ExpectFalse<StringIncludesProper<'NOT', 'NOT-INCLUDE', '0'>>,
+	//
+	ExpectTrue<StringIncludesProper<'abc', 'b', 1>>,
+	ExpectFalse<StringIncludesProper<'abc', 'bc', '1'>>,
+	ExpectFalse<StringIncludesProper<'abc', 'a', '1'>>,
+	ExpectFalse<StringIncludesProper<'abc', 'ab', '1'>>,
+	ExpectFalse<StringIncludesProper<'NOT', 'NOT-INCLUDE', '1'>>,
+	//
+	ExpectFalse<StringIncludesProper<'abc', 'c', 2>>,
+	ExpectFalse<StringIncludesProper<'abc', 'c', '2'>>,
+	ExpectFalse<StringIncludesProper<'abc', 'a', '2'>>,
+	ExpectFalse<StringIncludesProper<'abc', 'ab', '2'>>,
+	ExpectFalse<StringIncludesProper<'abc', 'abc', '2'>>,
+	ExpectFalse<StringIncludesProper<'NOT', 'NOT-INCLUDE', '2'>>
+]

--- a/src/strings/string-includes.ts
+++ b/src/strings/string-includes.ts
@@ -1,0 +1,77 @@
+import type { ExpectFalse, ExpectTrue } from '@type-challenges/utils'
+import type { Assert } from '../assert'
+import type { Chars } from './chars'
+import type { IndexOf } from '../index-of'
+import type { NumberLike } from '../number-like'
+import type { SplitAt } from './split-at'
+
+/**
+ * Check if a string literal includes another string literal, inclusive (⊆).
+ *
+ * @example
+ * ```
+ * type _StringIncludes_Cases = [
+ * 	ExpectTrue<StringIncludes<'abc', 'a'>>,
+ * 	ExpectTrue<StringIncludes<'abc', 'bc'>>,
+ * 	ExpectTrue<StringIncludes<'abc', 'abc'>>,
+ * 	ExpectFalse<StringIncludes<'NOT', 'NOT-INCLUDE'>>,
+ * 	//
+ * 	ExpectTrue<StringIncludes<'abc', '', 0>>,
+ * 	ExpectTrue<StringIncludes<'abc', '', '0'>>,
+ * 	ExpectTrue<StringIncludes<'abc', 'a', '0'>>,
+ * 	ExpectTrue<StringIncludes<'abc', 'abc', '0'>>,
+ * 	ExpectFalse<StringIncludes<'NOT', 'NOT-INCLUDE', '0'>>,
+ * 	//
+ * 	ExpectTrue<StringIncludes<'abc', 'b', 1>>,
+ * 	ExpectTrue<StringIncludes<'abc', 'bc', '1'>>,
+ * 	ExpectFalse<StringIncludes<'abc', 'a', '1'>>,
+ * 	ExpectFalse<StringIncludes<'abc', 'ab', '1'>>,
+ * 	ExpectFalse<StringIncludes<'NOT', 'NOT-INCLUDE', '1'>>,
+ * 	//
+ * 	ExpectTrue<StringIncludes<'abc', 'c', 2>>,
+ * 	ExpectTrue<StringIncludes<'abc', 'c', '2'>>,
+ * 	ExpectFalse<StringIncludes<'abc', 'a', '2'>>,
+ * 	ExpectFalse<StringIncludes<'abc', 'ab', '2'>>,
+ * 	ExpectFalse<StringIncludes<'abc', 'abc', '2'>>,
+ * 	ExpectFalse<StringIncludes<'NOT', 'NOT-INCLUDE', '2'>>
+ * ]
+ * ```
+ */
+export type StringIncludes<
+	S extends string,
+	Search extends string,
+	I extends NumberLike<IndexOf<Chars<S>>> = Assert<
+		0,
+		NumberLike<IndexOf<Chars<S>>>
+	>
+> = SplitAt<S, I> extends [infer _A, infer B]
+	? B extends `${infer _A}${Search}${infer _B}`
+		? true
+		: false
+	: never
+
+type _StringIncludes_Cases /* ⊆ */ = [
+	ExpectTrue<StringIncludes<'abc', 'a'>>,
+	ExpectTrue<StringIncludes<'abc', 'bc'>>,
+	ExpectTrue<StringIncludes<'abc', 'abc'>>,
+	ExpectFalse<StringIncludes<'NOT', 'NOT-INCLUDE'>>,
+	//
+	ExpectTrue<StringIncludes<'abc', '', 0>>,
+	ExpectTrue<StringIncludes<'abc', '', '0'>>,
+	ExpectTrue<StringIncludes<'abc', 'a', '0'>>,
+	ExpectTrue<StringIncludes<'abc', 'abc', '0'>>,
+	ExpectFalse<StringIncludes<'NOT', 'NOT-INCLUDE', '0'>>,
+	//
+	ExpectTrue<StringIncludes<'abc', 'b', 1>>,
+	ExpectTrue<StringIncludes<'abc', 'bc', '1'>>,
+	ExpectFalse<StringIncludes<'abc', 'a', '1'>>,
+	ExpectFalse<StringIncludes<'abc', 'ab', '1'>>,
+	ExpectFalse<StringIncludes<'NOT', 'NOT-INCLUDE', '1'>>,
+	//
+	ExpectTrue<StringIncludes<'abc', 'c', 2>>,
+	ExpectTrue<StringIncludes<'abc', 'c', '2'>>,
+	ExpectFalse<StringIncludes<'abc', 'a', '2'>>,
+	ExpectFalse<StringIncludes<'abc', 'ab', '2'>>,
+	ExpectFalse<StringIncludes<'abc', 'abc', '2'>>,
+	ExpectFalse<StringIncludes<'NOT', 'NOT-INCLUDE', '2'>>
+]

--- a/src/tuples/pop-by.ts
+++ b/src/tuples/pop-by.ts
@@ -1,0 +1,32 @@
+import type { Equal, ExpectTrue } from '@type-challenges/utils'
+import type { Subtract } from '../math/subtract'
+import type { UnknownArray } from '../unknown-array'
+
+/**
+ * Removes the last `N` elements from a tuple type. Does not return the removed types.
+ *
+ * @remarks Its worth noting `Pop`, `Push`, `Shift`, and `Unshift` are inspired by JS; however, the types are not 1:1 for design reasons. More information can be found in [README](
+ * @example
+ * ```
+ * declare const tuple: ['d', 'a', 'v', 'i', 'd']
+ * type Tuple = PopN<typeof tuple, 2> // ['d', 'a', 'v']
+ * ```
+ */
+export type PopBy<T extends UnknownArray, N extends number> = T extends [
+	...infer U,
+	any
+]
+	? N extends 0
+		? T
+		: PopBy<U, Subtract<N, 1>>
+	: T
+
+/**
+ * @internal
+ */
+type _PopBy_Cases = [
+	ExpectTrue<Equal<PopBy<['a', 'b', 'c'], 0>, ['a', 'b', 'c']>>,
+	ExpectTrue<Equal<PopBy<['a', 'b', 'c'], 1>, ['a', 'b']>>,
+	ExpectTrue<Equal<PopBy<['a', 'b', 'c'], 2>, ['a']>>,
+	ExpectTrue<Equal<PopBy<['a', 'b', 'c'], 3>, []>>
+]

--- a/src/tuples/shift-by.ts
+++ b/src/tuples/shift-by.ts
@@ -1,0 +1,32 @@
+import type { Equal, ExpectTrue } from '@type-challenges/utils'
+import type { Subtract } from '../math/subtract'
+import type { UnknownArray } from '../unknown-array'
+
+/**
+ * Removes the first `N` elements from a tuple type. Does not return the removed types.
+ *
+ * @remarks Its worth noting `Pop`, `Push`, `Shift`, and `Unshift` are inspired by JS; however, the types are not 1:1 for design reasons. More information can be found in [README](
+ * @example
+ * ```
+ * declare const tuple: ['d', 'a', 'v', 'i', 'd']
+ * type Tuple = ShiftN<typeof tuple, 2> // ['v', 'i', 'd']
+ * ```
+ */
+export type ShiftBy<T extends UnknownArray, N extends number> = T extends [
+	any,
+	...infer U
+]
+	? N extends 0
+		? T
+		: ShiftBy<U, Subtract<N, 1>>
+	: T
+
+/**
+ * @internal
+ */
+type _Cases = [
+	ExpectTrue<Equal<ShiftBy<['a', 'b', 'c'], 0>, ['a', 'b', 'c']>>,
+	ExpectTrue<Equal<ShiftBy<['a', 'b', 'c'], 1>, ['b', 'c']>>,
+	ExpectTrue<Equal<ShiftBy<['a', 'b', 'c'], 2>, ['c']>>,
+	ExpectTrue<Equal<ShiftBy<['a', 'b', 'c'], 3>, []>>
+]


### PR DESCRIPTION
I would like to have `StringIncludes` and `StringIncludesProper` generics. The String `includes` method has accepts a 2nd argument for the index to begin the search. To mimic that, I'll need a few new features 😈🔥.

- [X] Coercion types for better interop with `IndexOf`
- [X] `ShiftBy`
- [X] `PopBy`
- [x] `SplitAt`
- [x] `StringIncludes` and `StringIncludesProper` 